### PR TITLE
GH-221 Add Enum argument resolver

### DIFF
--- a/litecommands-annotations/test/dev/rollczi/litecommands/annotations/argument/resolver/standard/EnumArgumentTest.java
+++ b/litecommands-annotations/test/dev/rollczi/litecommands/annotations/argument/resolver/standard/EnumArgumentTest.java
@@ -30,7 +30,7 @@ class EnumArgumentTest extends LiteTestSpec {
             .assertSuccess(TestEnum.FIRST);
 
         platform.execute("test SECOND")
-            .assertSuccess(TestEnum.FIRST);
+            .assertSuccess(TestEnum.SECOND);
     }
 
     @Test

--- a/litecommands-annotations/test/dev/rollczi/litecommands/annotations/argument/resolver/standard/EnumArgumentTest.java
+++ b/litecommands-annotations/test/dev/rollczi/litecommands/annotations/argument/resolver/standard/EnumArgumentTest.java
@@ -28,11 +28,24 @@ class EnumArgumentTest extends LiteTestSpec {
     void test() {
         platform.execute("test FIRST")
             .assertSuccess(TestEnum.FIRST);
+
+        platform.execute("test SECOND")
+            .assertSuccess(TestEnum.FIRST);
     }
 
     @Test
     void testInvalid() {
-        platform.execute("test fodfds")
+        platform.execute("test invalid")
             .assertFailure();
     }
+
+    @Test
+    void testSuggestions() {
+        platform.suggest("test ")
+            .assertSuggest("FIRST", "SECOND");
+
+        platform.suggest("test F")
+            .assertSuggest("FIRST");
+    }
+
 }

--- a/litecommands-annotations/test/dev/rollczi/litecommands/annotations/argument/resolver/standard/EnumArgumentTest.java
+++ b/litecommands-annotations/test/dev/rollczi/litecommands/annotations/argument/resolver/standard/EnumArgumentTest.java
@@ -1,0 +1,38 @@
+package dev.rollczi.litecommands.annotations.argument.resolver.standard;
+
+import dev.rollczi.litecommands.annotations.LiteTestSpec;
+import dev.rollczi.litecommands.annotations.argument.Arg;
+import dev.rollczi.litecommands.annotations.command.Command;
+import dev.rollczi.litecommands.annotations.execute.Execute;
+import org.junit.jupiter.api.Test;
+
+import java.time.Duration;
+
+class EnumArgumentTest extends LiteTestSpec {
+
+    @Command(name = "test")
+    static class TestCommand {
+
+        @Execute
+        TestEnum test(@Arg TestEnum testEnum) {
+            return testEnum;
+        }
+    }
+
+    enum TestEnum {
+        FIRST,
+        SECOND,
+    }
+
+    @Test
+    void test() {
+        platform.execute("test FIRST")
+            .assertSuccess(TestEnum.FIRST);
+    }
+
+    @Test
+    void testInvalid() {
+        platform.execute("test fodfds")
+            .assertFailure();
+    }
+}

--- a/litecommands-annotations/test/dev/rollczi/litecommands/annotations/argument/resolver/standard/EnumArgumentTest.java
+++ b/litecommands-annotations/test/dev/rollczi/litecommands/annotations/argument/resolver/standard/EnumArgumentTest.java
@@ -46,6 +46,10 @@ class EnumArgumentTest extends LiteTestSpec {
 
         platform.suggest("test F")
             .assertSuggest("FIRST");
+
+        // test cached suggestions (test mutable state)
+        platform.suggest("test ")
+            .assertSuggest("FIRST", "SECOND");
     }
 
 }

--- a/litecommands-core/src/dev/rollczi/litecommands/argument/parser/EmptyParserSetImpl.java
+++ b/litecommands-core/src/dev/rollczi/litecommands/argument/parser/EmptyParserSetImpl.java
@@ -1,0 +1,18 @@
+package dev.rollczi.litecommands.argument.parser;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Optional;
+
+class EmptyParserSetImpl<SENDER, PARSED> implements ParserSet<SENDER, PARSED> {
+    @Override
+    public <INPUT> Optional<Parser<SENDER, INPUT, PARSED>> getParser(Class<INPUT> inType) {
+        return Optional.empty();
+    }
+
+    @Override
+    public Collection<Parser<SENDER, ?, PARSED>> getParsers() {
+        return Collections.emptyList();
+    }
+
+}

--- a/litecommands-core/src/dev/rollczi/litecommands/argument/parser/ParserSetImpl.java
+++ b/litecommands-core/src/dev/rollczi/litecommands/argument/parser/ParserSetImpl.java
@@ -55,19 +55,4 @@ class ParserSetImpl<SENDER, PARSED> implements ParserSet<SENDER, PARSED> {
         parsers.put(parser.getInputType(), parser);
     }
 
-    private class EmptyParserSetImpl implements ParserSet<SENDER,PARSED> {
-        @Override
-        public <INPUT> Optional<Parser<SENDER, INPUT, PARSED>> getParser(Class<INPUT> inType) {
-            return Optional.empty();
-        }
-
-        @Override
-        public Collection<Parser<SENDER, ?, PARSED>> getParsers() {
-            return Collections.emptyList();
-        }
-
-        public Class<PARSED> getParsedType() {
-            throw new UnsupportedOperationException();
-        }
-    }
 }

--- a/litecommands-core/src/dev/rollczi/litecommands/argument/resolver/standard/EnumArgumentResolver.java
+++ b/litecommands-core/src/dev/rollczi/litecommands/argument/resolver/standard/EnumArgumentResolver.java
@@ -8,7 +8,14 @@ import dev.rollczi.litecommands.invocation.Invocation;
 import dev.rollczi.litecommands.suggestion.SuggestionContext;
 import dev.rollczi.litecommands.suggestion.SuggestionResult;
 
+import java.util.Arrays;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+@SuppressWarnings("rawtypes")
 public class EnumArgumentResolver<SENDER> extends ArgumentResolver<SENDER, Enum> {
+
+    private final Map<Class<?>, SuggestionResult> cachedEnumSuggestions = new ConcurrentHashMap<>();
 
     @Override
     protected ParseResult<Enum> parse(Invocation<SENDER> invocation, Argument<Enum> context, String argument) {
@@ -21,10 +28,18 @@ public class EnumArgumentResolver<SENDER> extends ArgumentResolver<SENDER, Enum>
 
     @Override
     public SuggestionResult suggest(Invocation<SENDER> invocation, Argument<Enum> argument, SuggestionContext context) {
-        return super.suggest(invocation, argument, context);
+        return cachedEnumSuggestions.computeIfAbsent(argument.getWrapperFormat().getParsedType(), clazz -> {
+            final Object[] enumConstants = clazz.getEnumConstants();
+            if (enumConstants == null || enumConstants.length == 0) {
+                return SuggestionResult.empty();
+            }
+
+
+            return Arrays.stream(enumConstants).map(Object::toString).collect(SuggestionResult.collector());
+        });
     }
 
-    @SuppressWarnings({"unchecked", "rawtypes"})
+    @SuppressWarnings("unchecked")
     private Enum getEnum(Class<? extends Enum> clazz, String name) throws IllegalArgumentException {
         return Enum.valueOf(clazz, name);
     }

--- a/litecommands-core/src/dev/rollczi/litecommands/argument/resolver/standard/EnumArgumentResolver.java
+++ b/litecommands-core/src/dev/rollczi/litecommands/argument/resolver/standard/EnumArgumentResolver.java
@@ -1,0 +1,31 @@
+package dev.rollczi.litecommands.argument.resolver.standard;
+
+import dev.rollczi.litecommands.argument.Argument;
+import dev.rollczi.litecommands.argument.parser.ParseResult;
+import dev.rollczi.litecommands.argument.resolver.ArgumentResolver;
+import dev.rollczi.litecommands.invalidusage.InvalidUsage;
+import dev.rollczi.litecommands.invocation.Invocation;
+import dev.rollczi.litecommands.suggestion.SuggestionContext;
+import dev.rollczi.litecommands.suggestion.SuggestionResult;
+
+public class EnumArgumentResolver<SENDER> extends ArgumentResolver<SENDER, Enum> {
+
+    @Override
+    protected ParseResult<Enum> parse(Invocation<SENDER> invocation, Argument<Enum> context, String argument) {
+        try {
+            return ParseResult.success(getEnum(context.getWrapperFormat().getParsedType(), argument));
+        } catch (IllegalArgumentException e) {
+            return ParseResult.failure(InvalidUsage.Cause.INVALID_ARGUMENT);
+        }
+    }
+
+    @Override
+    public SuggestionResult suggest(Invocation<SENDER> invocation, Argument<Enum> argument, SuggestionContext context) {
+        return super.suggest(invocation, argument, context);
+    }
+
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    private Enum getEnum(Class<? extends Enum> clazz, String name) throws IllegalArgumentException {
+        return Enum.valueOf(clazz, name);
+    }
+}

--- a/litecommands-core/src/dev/rollczi/litecommands/argument/suggester/SuggesterRegistryImpl.java
+++ b/litecommands-core/src/dev/rollczi/litecommands/argument/suggester/SuggesterRegistryImpl.java
@@ -3,10 +3,12 @@ package dev.rollczi.litecommands.argument.suggester;
 import dev.rollczi.litecommands.argument.ArgumentKey;
 import dev.rollczi.litecommands.shared.BiHashMap;
 import dev.rollczi.litecommands.shared.BiMap;
+import dev.rollczi.litecommands.util.MapUtil;
 import dev.rollczi.litecommands.util.StringUtil;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Optional;
 
 public class SuggesterRegistryImpl<SENDER> implements SuggesterRegistry<SENDER> {
 
@@ -25,12 +27,13 @@ public class SuggesterRegistryImpl<SENDER> implements SuggesterRegistry<SENDER> 
     @Override
     @SuppressWarnings("unchecked")
     public <PARSED> Suggester<SENDER, PARSED> getSuggester(Class<PARSED> parsedClass, ArgumentKey key) {
-        BucketByArgument<PARSED> bucket = (BucketByArgument<PARSED>) buckets.get(parsedClass);
+        Optional<BucketByArgument<?>> optional = MapUtil.findBySuperTypeOf(parsedClass, buckets);
 
-        if (bucket == null) {
+        if (!optional.isPresent()) {
             return (Suggester<SENDER, PARSED>) noneSuggester;
         }
 
+        BucketByArgument<PARSED> bucket = (BucketByArgument<PARSED>) optional.get();
         Suggester<SENDER, PARSED> suggester = bucket.getSuggester(key);
 
         if (suggester == null) {

--- a/litecommands-core/test/dev/rollczi/litecommands/argument/suggester/SuggesterRegistryImplTest.java
+++ b/litecommands-core/test/dev/rollczi/litecommands/argument/suggester/SuggesterRegistryImplTest.java
@@ -1,0 +1,102 @@
+package dev.rollczi.litecommands.argument.suggester;
+
+import dev.rollczi.litecommands.argument.Argument;
+import dev.rollczi.litecommands.argument.ArgumentKey;
+import dev.rollczi.litecommands.invocation.Invocation;
+import dev.rollczi.litecommands.suggestion.Suggestion;
+import dev.rollczi.litecommands.suggestion.SuggestionContext;
+import dev.rollczi.litecommands.suggestion.SuggestionResult;
+import dev.rollczi.litecommands.unit.TestSender;
+import org.junit.jupiter.api.Test;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+
+class SuggesterRegistryImplTest {
+
+    @Test
+    void registerSuggester() {
+        SuggesterRegistryImpl<TestSender> registry = new SuggesterRegistryImpl<>();
+
+        registry.registerSuggester(String.class, ArgumentKey.of(), new NamedSuggester("universal"));
+
+        Suggester<TestSender, String> universal = registry.getSuggester(String.class, ArgumentKey.of());
+        SuggestionResult suggest = universal.suggest(null, null, null);
+
+        assertSuggestion("universal", suggest);
+    }
+
+    @Test
+    void registerCustomSuggester() {
+        SuggesterRegistryImpl<TestSender> registry = new SuggesterRegistryImpl<>();
+
+        registry.registerSuggester(String.class, ArgumentKey.of("custom"), new NamedSuggester("custom"));
+        registry.registerSuggester(String.class, ArgumentKey.of(), new NamedSuggester("universal"));
+
+        Suggester<TestSender, String> custom = registry.getSuggester(String.class, ArgumentKey.of("custom"));
+        Suggester<TestSender, String> universal = registry.getSuggester(String.class, ArgumentKey.of());
+        Suggester<TestSender, String> missing = registry.getSuggester(String.class, ArgumentKey.of("missing"));
+
+        SuggestionResult customSuggest = custom.suggest(null, null, null);
+        SuggestionResult universalSuggest = universal.suggest(null, null, null);
+        SuggestionResult missingSuggest = missing.suggest(null, null, null);
+
+        assertSuggestion("custom", customSuggest);
+        assertSuggestion("universal", universalSuggest);
+        assertSuggestion("universal", missingSuggest);
+    }
+
+    @Test
+    void registerGenericSuggester() {
+        SuggesterRegistryImpl<TestSender> registry = new SuggesterRegistryImpl<>();
+
+        registry.registerSuggester(Number.class, ArgumentKey.of(), new NumberSuggester());
+
+        Suggester<TestSender, Number> universal = registry.getSuggester(Number.class, ArgumentKey.of());
+        Suggester<TestSender, Integer> integer = registry.getSuggester(Integer.class, ArgumentKey.of());
+
+        SuggestionResult universalSuggest = universal.suggest(null, null, null);
+        SuggestionResult integerSuggest = integer.suggest(null, null, null);
+
+        assertSuggestion("number", universalSuggest);
+        assertSuggestion("number", integerSuggest);
+    }
+
+    private <T> T assertOptional(Optional<T> optional) {
+        assertTrue(optional.isPresent());
+        return optional.get();
+    }
+
+    private void assertSuggestion(String expected, SuggestionResult result) {
+        assertThat(result.getSuggestions())
+            .hasSize(1);
+
+        Suggestion suggestion = assertOptional(result.getSuggestions().stream().findFirst());
+
+        assertThat(suggestion.multilevel())
+            .isEqualTo(expected);
+    }
+
+    private static class NamedSuggester implements Suggester<TestSender, String> {
+        private final String name;
+
+        public NamedSuggester(String name) {
+            this.name = name;
+        }
+
+        @Override
+        public SuggestionResult suggest(Invocation<TestSender> invocation, Argument<String> argument, SuggestionContext context) {
+            return SuggestionResult.of(name);
+        }
+    }
+
+    private static class NumberSuggester implements Suggester<TestSender, Number> {
+        @Override
+        public SuggestionResult suggest(Invocation<TestSender> invocation, Argument<Number> argument, SuggestionContext context) {
+            return SuggestionResult.of("number");
+        }
+    }
+
+}

--- a/litecommands-framework/src/dev/rollczi/litecommands/LiteCommandsFactory.java
+++ b/litecommands-framework/src/dev/rollczi/litecommands/LiteCommandsFactory.java
@@ -1,6 +1,7 @@
 package dev.rollczi.litecommands;
 
 import dev.rollczi.litecommands.argument.resolver.standard.DurationArgumentResolver;
+import dev.rollczi.litecommands.argument.resolver.standard.EnumArgumentResolver;
 import dev.rollczi.litecommands.argument.resolver.standard.NumberArgumentResolver;
 import dev.rollczi.litecommands.argument.resolver.standard.PeriodArgumentResolver;
 import dev.rollczi.litecommands.argument.resolver.standard.StringArgumentResolver;
@@ -71,6 +72,7 @@ public final class LiteCommandsFactory {
                 .argument(short.class, NumberArgumentResolver.ofShort())
                 .argument(Duration.class, new DurationArgumentResolver<>())
                 .argument(Period.class, new PeriodArgumentResolver<>())
+                .argument(Enum.class, new EnumArgumentResolver<>())
 
                 .argumentParser(String.class, JoinArgument.KEY, new JoinStringArgumentResolver<>())
                 .argument(boolean.class, FlagArgument.KEY, new FlagArgumentResolver<>())

--- a/litecommands-unit/src/dev/rollczi/litecommands/unit/AssertSuggest.java
+++ b/litecommands-unit/src/dev/rollczi/litecommands/unit/AssertSuggest.java
@@ -3,6 +3,7 @@ package dev.rollczi.litecommands.unit;
 import dev.rollczi.litecommands.suggestion.Suggestion;
 import dev.rollczi.litecommands.suggestion.SuggestionResult;
 
+import java.util.Arrays;
 import java.util.Set;
 
 import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
@@ -19,7 +20,7 @@ public class AssertSuggest {
         Set<Suggestion> actualSuggestions = suggest.getSuggestions();
 
         assertThat(actualSuggestions.stream().map(Suggestion::multilevel))
-            .containsExactly(suggestions);
+            .containsAll(Arrays.asList(suggestions));
 
         return this;
     }

--- a/litecommands-unit/src/dev/rollczi/litecommands/unit/AssertSuggest.java
+++ b/litecommands-unit/src/dev/rollczi/litecommands/unit/AssertSuggest.java
@@ -5,6 +5,8 @@ import dev.rollczi.litecommands.suggestion.SuggestionResult;
 
 import java.util.Set;
 
+import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
+
 public class AssertSuggest {
 
     private final SuggestionResult suggest;
@@ -16,15 +18,8 @@ public class AssertSuggest {
     public AssertSuggest assertSuggest(String... suggestions) {
         Set<Suggestion> actualSuggestions = suggest.getSuggestions();
 
-        if (suggestions.length != actualSuggestions.size()) {
-            throw new AssertionError("Expected " + suggestions.length + " suggestions, but got " + actualSuggestions.size() + " " + actualSuggestions);
-        }
-
-        for (String suggestion : suggestions) {
-            if (!actualSuggestions.contains(Suggestion.of(suggestion))) {
-                throw new AssertionError("Expected suggestion " + suggestion + " but not found in " + actualSuggestions);
-            }
-        }
+        assertThat(actualSuggestions.stream().map(Suggestion::multilevel))
+            .containsExactly(suggestions);
 
         return this;
     }


### PR DESCRIPTION
Closes #221

Now it doesn't work for some reason - I get `No parser for RawInput -> dev.rollczi.litecommands.annotations.argument.resolver.standard.EnumArgumentTest$TestEnum` for `test` and `testInvalid` not being failed. I can't understand, why