### PR TITLE
GH-304 Modify Description meta type to a String list 

### DIFF
--- a/litecommands-annotations/src/dev/rollczi/litecommands/annotations/description/Description.java
+++ b/litecommands-annotations/src/dev/rollczi/litecommands/annotations/description/Description.java
@@ -9,6 +9,6 @@ import java.lang.annotation.Target;
 @Target({ElementType.PARAMETER, ElementType.METHOD, ElementType.TYPE})
 public @interface Description {
 
-    String value();
+    String[] value();
 
 }

--- a/litecommands-annotations/src/dev/rollczi/litecommands/annotations/description/DescriptionAnnotationResolver.java
+++ b/litecommands-annotations/src/dev/rollczi/litecommands/annotations/description/DescriptionAnnotationResolver.java
@@ -12,7 +12,7 @@ public class DescriptionAnnotationResolver<SENDER> implements AnnotationProcesso
     @Override
     public AnnotationInvoker<SENDER> process(AnnotationInvoker<SENDER> invoker) {
         return invoker.on(Description.class, (annotation, metaHolder) -> {
-            metaHolder.meta().put(Meta.DESCRIPTION, Arrays.stream(annotation.value()).collect(Collectors.toList()));
+            metaHolder.meta().put(Meta.DESCRIPTION, Arrays.asList(annotation.value()));
         });
     }
 

--- a/litecommands-annotations/src/dev/rollczi/litecommands/annotations/description/DescriptionAnnotationResolver.java
+++ b/litecommands-annotations/src/dev/rollczi/litecommands/annotations/description/DescriptionAnnotationResolver.java
@@ -4,12 +4,15 @@ import dev.rollczi.litecommands.annotations.AnnotationInvoker;
 import dev.rollczi.litecommands.annotations.AnnotationProcessor;
 import dev.rollczi.litecommands.meta.Meta;
 
+import java.util.Arrays;
+import java.util.stream.Collectors;
+
 public class DescriptionAnnotationResolver<SENDER> implements AnnotationProcessor<SENDER> {
 
     @Override
     public AnnotationInvoker<SENDER> process(AnnotationInvoker<SENDER> invoker) {
         return invoker.on(Description.class, (annotation, metaHolder) -> {
-            metaHolder.meta().put(Meta.DESCRIPTION, annotation.value());
+            metaHolder.meta().put(Meta.DESCRIPTION, Arrays.stream(annotation.value()).collect(Collectors.toList()));
         });
     }
 

--- a/litecommands-core/src/dev/rollczi/litecommands/meta/Meta.java
+++ b/litecommands-core/src/dev/rollczi/litecommands/meta/Meta.java
@@ -3,7 +3,6 @@ package dev.rollczi.litecommands.meta;
 import dev.rollczi.litecommands.scheduler.SchedulerPoll;
 import dev.rollczi.litecommands.validator.Validator;
 import dev.rollczi.litecommands.validator.requirment.RequirementValidator;
-
 import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
 
@@ -16,7 +15,7 @@ import java.util.function.UnaryOperator;
 @SuppressWarnings("rawtypes")
 public interface Meta {
 
-    MetaKey<String> DESCRIPTION = MetaKey.of("description", String.class, "none");
+    MetaKey<List<String>> DESCRIPTION = MetaKey.of("description", MetaType.list(), Collections.emptyList());
     MetaKey<List<String>> PERMISSIONS = MetaKey.of("permissions", MetaType.list(), Collections.emptyList());
     MetaKey<Boolean> NATIVE_PERMISSIONS = MetaKey.of("native-permissions", Boolean.class, false);
     MetaKey<SchedulerPoll> POLL_TYPE = MetaKey.of("poll-type", SchedulerPoll.class, SchedulerPoll.MAIN);

--- a/litecommands-jda/test/dev/rollczi/litecommands/jda/JDACommandTranslatorTest.java
+++ b/litecommands-jda/test/dev/rollczi/litecommands/jda/JDACommandTranslatorTest.java
@@ -34,7 +34,11 @@ class JDACommandTranslatorTest {
     void test() {
         CommandRoute<TestSender> root = CommandRoute.createRoot();
         CommandRoute<TestSender> siema = CommandRoute.create(root, COMMAND, List.of());
-        siema.meta().put(Meta.DESCRIPTION, DESCRIPTION);
+        siema.meta()
+            .listEditor(Meta.DESCRIPTION)
+            .add(DESCRIPTION)
+            .apply();
+
         siema.appendExecutor(simpleExecutor(siema));
 
         JDACommandTranslator.JDALiteCommand translated = translator.translate(COMMAND, siema);
@@ -59,7 +63,10 @@ class JDACommandTranslatorTest {
     void subcommandsAndGroup() {
         CommandRoute<TestSender> root = CommandRoute.createRoot();
         CommandRoute<TestSender> command = CommandRoute.create(root, COMMAND, List.of());
-        command.meta().put(Meta.DESCRIPTION, DESCRIPTION);
+        command.meta()
+            .listEditor(Meta.DESCRIPTION)
+            .add(DESCRIPTION)
+            .apply();
 
         CommandRoute<TestSender> subCommand = CommandRoute.create(command, SUB_COMMAND, List.of());
         command.appendChildren(subCommand);


### PR DESCRIPTION
In this pull request:

- Add a new builder function `schematicGenerator(BiFunction<ValidatorService<SENDER>, WrapperRegistry, SchematicGenerator<SENDER>> schematicGenerator)`.
- Cleaned the unused imports.
- Modify "DESCRIPTION" meta type to a String list.

That means other developers can create a new SchematicGenerator more easily and elegant with `ValidatorService` and `WrapperRegistry` provided. Also means that it is possible to generate multi-line descriptions about a single executor.

For example:

```java
    @Execute(name = "command")
    @Description({"Send player a value!", "Value will be superman if null."})
    public void getAccount(@Context CommandSender sender, @Arg("player") Player player, @Arg("value") Optional<String> optValue) {


    }
```
```text
# send<player> [value]
- Send player a value!
- Value will be superman if null.
```