### PR TITLE
GH-373 Fix errors in the findByInstanceOf method

### DIFF
--- a/litecommands-core/src/dev/rollczi/litecommands/util/MapUtil.java
+++ b/litecommands-core/src/dev/rollczi/litecommands/util/MapUtil.java
@@ -17,7 +17,7 @@ public final class MapUtil {
 
         for (Map.Entry<Class<?>, E> entry : map.entrySet()) {
             if (type.isAssignableFrom(entry.getKey())) {
-                return Optional.of(entry.getValue());
+                return Optional.ofNullable(entry.getValue());
             }
         }
 


### PR DESCRIPTION
```
java.lang.NullPointerException
	at java.util.Objects.requireNonNull(Objects.java:203)
	at java.util.Optional.<init>(Optional.java:96)
	at java.util.Optional.of(Optional.java:108)
	at dev.rollczi.litecommands.util.MapUtil.findByInstanceOf(MapUtil.java:20)
	at dev.rollczi.litecommands.invocation.InvocationContext.get(InvocationContext.java:18)
```

InvocationContext.Builder#put(java.lang.Class<T>, T)  The value of may be null