### PR TITLE
GH-438 Bukkit OfflinePlayer argument

### DIFF
--- a/examples/bukkit/src/main/java/dev/rollczi/example/bukkit/ExamplePlugin.java
+++ b/examples/bukkit/src/main/java/dev/rollczi/example/bukkit/ExamplePlugin.java
@@ -9,6 +9,7 @@ import dev.rollczi.example.bukkit.command.FlyCommand;
 import dev.rollczi.example.bukkit.command.GameModeCommand;
 import dev.rollczi.example.bukkit.command.KickCommand;
 import dev.rollczi.example.bukkit.command.NumberCommand;
+import dev.rollczi.example.bukkit.command.OfflineInfoCommand;
 import dev.rollczi.example.bukkit.command.RandomItemCommand;
 import dev.rollczi.example.bukkit.command.TeleportCommand;
 import dev.rollczi.example.bukkit.command.currency.CurrencyBalanceCommand;
@@ -49,6 +50,7 @@ public class ExamplePlugin extends JavaPlugin {
 
             // Commands
             .commands(
+                new OfflineInfoCommand(),
                 new ConvertCommand(),
                 new GameModeCommand(),
                 new KickCommand(),

--- a/examples/bukkit/src/main/java/dev/rollczi/example/bukkit/command/OfflineInfoCommand.java
+++ b/examples/bukkit/src/main/java/dev/rollczi/example/bukkit/command/OfflineInfoCommand.java
@@ -1,0 +1,31 @@
+package dev.rollczi.example.bukkit.command;
+
+import dev.rollczi.example.bukkit.util.ChatUtil;
+import dev.rollczi.litecommands.annotations.argument.Arg;
+import dev.rollczi.litecommands.annotations.async.Async;
+import dev.rollczi.litecommands.annotations.command.Command;
+import dev.rollczi.litecommands.annotations.context.Context;
+import dev.rollczi.litecommands.annotations.execute.Execute;
+import java.time.Duration;
+import java.time.Instant;
+import org.bukkit.OfflinePlayer;
+import org.bukkit.command.CommandSender;
+
+@Command(name = "offline-info")
+public class OfflineInfoCommand {
+
+    @Execute
+    void executeOfflineInfo(
+        @Context CommandSender sender,
+        @Arg OfflinePlayer offlinePlayer
+    ) {
+        String online = "&7(" + (offlinePlayer.isOnline() ? "&aonline" : "&coffline") + "&7)";
+        Instant lastPlayed = Instant.ofEpochMilli(offlinePlayer.getLastPlayed());
+        String lastPlayedFormatted = Duration.between(lastPlayed, Instant.now()).toHours() + "h";
+
+        sender.sendMessage(ChatUtil.color("&7Player: &e" + offlinePlayer.getName() + " " + online));
+        sender.sendMessage(ChatUtil.color("&7uuid: " + offlinePlayer.getUniqueId()));
+        sender.sendMessage(ChatUtil.color("&7Last played: &e" + lastPlayedFormatted));
+    }
+
+}

--- a/litecommands-bukkit/src/dev/rollczi/litecommands/bukkit/LiteBukkitFactory.java
+++ b/litecommands-bukkit/src/dev/rollczi/litecommands/bukkit/LiteBukkitFactory.java
@@ -3,6 +3,7 @@ package dev.rollczi.litecommands.bukkit;
 import dev.rollczi.litecommands.LiteCommandsBuilder;
 import dev.rollczi.litecommands.LiteCommandsFactory;
 import dev.rollczi.litecommands.bukkit.argument.LocationArgument;
+import dev.rollczi.litecommands.bukkit.argument.OfflinePlayerArgument;
 import dev.rollczi.litecommands.bukkit.argument.PlayerArgument;
 import dev.rollczi.litecommands.bukkit.argument.WorldArgument;
 import dev.rollczi.litecommands.bukkit.context.LocationContext;
@@ -12,6 +13,7 @@ import dev.rollczi.litecommands.message.MessageRegistry;
 import java.util.Locale;
 import org.bukkit.Bukkit;
 import org.bukkit.Location;
+import org.bukkit.OfflinePlayer;
 import org.bukkit.Server;
 import org.bukkit.World;
 import org.bukkit.command.CommandSender;
@@ -26,20 +28,21 @@ public final class LiteBukkitFactory {
     }
 
     public static <B extends LiteCommandsBuilder<CommandSender, LiteBukkitSettings, B>> B builder() {
-        JavaPlugin plugin = JavaPlugin.getProvidingPlugin(LiteBukkitFactory.class);
-        String name = plugin.getDescription().getName()
-            .toLowerCase(Locale.ROOT)
-            .replace(" ", "-");
-
-        return builder(name, plugin, plugin.getServer());
+        Plugin plugin = JavaPlugin.getProvidingPlugin(LiteBukkitFactory.class);
+        return builder(createFallbackPrefix(plugin), plugin, plugin.getServer());
     }
 
     public static <B extends LiteCommandsBuilder<CommandSender, LiteBukkitSettings, B>> B builder(String fallbackPrefix) {
-        return builder(fallbackPrefix, JavaPlugin.getProvidingPlugin(LiteBukkitFactory.class), Bukkit.getServer());
+        Plugin plugin = JavaPlugin.getProvidingPlugin(LiteBukkitFactory.class);
+        return builder(fallbackPrefix, plugin, plugin.getServer());
+    }
+
+    public static <B extends LiteCommandsBuilder<CommandSender, LiteBukkitSettings, B>> B builder(Plugin plugin) {
+        return builder(createFallbackPrefix(plugin), plugin, plugin.getServer());
     }
 
     public static <B extends LiteCommandsBuilder<CommandSender, LiteBukkitSettings, B>> B builder(String fallbackPrefix, Plugin plugin) {
-        return builder(fallbackPrefix, plugin, Bukkit.getServer());
+        return builder(fallbackPrefix, plugin, plugin.getServer());
     }
 
     public static <B extends LiteCommandsBuilder<CommandSender, LiteBukkitSettings, B>> B builder(String fallbackPrefix, Plugin plugin, Server server) {
@@ -55,6 +58,7 @@ public final class LiteBukkitFactory {
             MessageRegistry<CommandSender> messageRegistry = internal.getMessageRegistry();
 
             builder
+                .bind(Plugin.class, () -> plugin)
                 .bind(Server.class, () -> server)
                 .bind(BukkitScheduler.class, () -> server.getScheduler())
 
@@ -65,6 +69,7 @@ public final class LiteBukkitFactory {
                 .argument(Player.class, new PlayerArgument(server, messageRegistry))
                 .argument(World.class, new WorldArgument(server, messageRegistry))
                 .argument(Location.class, new LocationArgument(messageRegistry))
+                .argument(OfflinePlayer.class, new OfflinePlayerArgument(server, plugin, true))
 
                 .context(Player.class, new PlayerOnlyContextProvider(messageRegistry))
                 .context(World.class, new WorldContext(messageRegistry))
@@ -74,4 +79,9 @@ public final class LiteBukkitFactory {
         });
     }
 
+    public static String createFallbackPrefix(Plugin plugin) {
+        return plugin.getName()
+            .toLowerCase(Locale.ROOT)
+            .replace(" ", "-");
+    }
 }

--- a/litecommands-bukkit/src/dev/rollczi/litecommands/bukkit/LiteBukkitFactory.java
+++ b/litecommands-bukkit/src/dev/rollczi/litecommands/bukkit/LiteBukkitFactory.java
@@ -9,9 +9,8 @@ import dev.rollczi.litecommands.bukkit.argument.WorldArgument;
 import dev.rollczi.litecommands.bukkit.context.LocationContext;
 import dev.rollczi.litecommands.bukkit.context.PlayerOnlyContextProvider;
 import dev.rollczi.litecommands.bukkit.context.WorldContext;
+import dev.rollczi.litecommands.bukkit.util.BukkitFallbackPrefixUtil;
 import dev.rollczi.litecommands.message.MessageRegistry;
-import java.util.Locale;
-import org.bukkit.Bukkit;
 import org.bukkit.Location;
 import org.bukkit.OfflinePlayer;
 import org.bukkit.Server;
@@ -29,7 +28,7 @@ public final class LiteBukkitFactory {
 
     public static <B extends LiteCommandsBuilder<CommandSender, LiteBukkitSettings, B>> B builder() {
         Plugin plugin = JavaPlugin.getProvidingPlugin(LiteBukkitFactory.class);
-        return builder(createFallbackPrefix(plugin), plugin, plugin.getServer());
+        return builder(BukkitFallbackPrefixUtil.create(plugin), plugin, plugin.getServer());
     }
 
     public static <B extends LiteCommandsBuilder<CommandSender, LiteBukkitSettings, B>> B builder(String fallbackPrefix) {
@@ -38,7 +37,7 @@ public final class LiteBukkitFactory {
     }
 
     public static <B extends LiteCommandsBuilder<CommandSender, LiteBukkitSettings, B>> B builder(Plugin plugin) {
-        return builder(createFallbackPrefix(plugin), plugin, plugin.getServer());
+        return builder(BukkitFallbackPrefixUtil.create(plugin), plugin, plugin.getServer());
     }
 
     public static <B extends LiteCommandsBuilder<CommandSender, LiteBukkitSettings, B>> B builder(String fallbackPrefix, Plugin plugin) {
@@ -79,9 +78,4 @@ public final class LiteBukkitFactory {
         });
     }
 
-    public static String createFallbackPrefix(Plugin plugin) {
-        return plugin.getName()
-            .toLowerCase(Locale.ROOT)
-            .replace(" ", "-");
-    }
 }

--- a/litecommands-bukkit/src/dev/rollczi/litecommands/bukkit/argument/OfflinePlayerArgument.java
+++ b/litecommands-bukkit/src/dev/rollczi/litecommands/bukkit/argument/OfflinePlayerArgument.java
@@ -1,35 +1,31 @@
 package dev.rollczi.litecommands.bukkit.argument;
 
-import com.google.common.collect.Sets;
 import dev.rollczi.litecommands.argument.Argument;
 import dev.rollczi.litecommands.argument.parser.ParseResult;
 import dev.rollczi.litecommands.argument.resolver.ArgumentResolver;
-import dev.rollczi.litecommands.bukkit.LiteBukkitMessages;
 import dev.rollczi.litecommands.invocation.Invocation;
-import dev.rollczi.litecommands.message.MessageRegistry;
 import dev.rollczi.litecommands.suggestion.SuggestionContext;
 import dev.rollczi.litecommands.suggestion.SuggestionResult;
+import java.util.TreeSet;
 import org.bukkit.OfflinePlayer;
 import org.bukkit.Server;
 import org.bukkit.command.CommandSender;
-import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 import org.bukkit.event.player.PlayerJoinEvent;
 import org.bukkit.plugin.Plugin;
 
 import java.time.Instant;
-import java.util.Arrays;
-import java.util.Set;
-import java.util.stream.Collectors;
 
 public class OfflinePlayerArgument extends ArgumentResolver<CommandSender, OfflinePlayer> {
+
+    private static final int SUGGESTION_LIMIT = 256;
 
     private final Server server;
     private final Plugin plugin;
     private final boolean enableThreadCheck;
 
-    private final Set<String> nicknames = Sets.newConcurrentHashSet();
+    private final TreeSet<String> nicknames = new TreeSet<>(String.CASE_INSENSITIVE_ORDER);
     private Instant nextWarningDate = Instant.EPOCH;
 
     public OfflinePlayerArgument(Server server, Plugin plugin, boolean enableThreadCheck) {
@@ -38,13 +34,12 @@ public class OfflinePlayerArgument extends ArgumentResolver<CommandSender, Offli
         this.enableThreadCheck = enableThreadCheck;
 
         // Server#getOfflinePlayers() can be blocking, so we don't want to call it every time
-        nicknames.addAll(
-            Arrays.stream(server.getOfflinePlayers())
-                .map(OfflinePlayer::getName)
-                .collect(Collectors.toList())
-        );
+        for (OfflinePlayer offlinePlayer : server.getOfflinePlayers()) {
+            this.nicknames.add(offlinePlayer.getName());
+        }
 
         // Save new joining player names so our suggestions are more wide
+        // TODO: Unregister this listener on Platform#unregister()
         server.getPluginManager().registerEvents(new Listener() {
             @EventHandler
             public void onPlayerJoin(PlayerJoinEvent event) {
@@ -56,8 +51,9 @@ public class OfflinePlayerArgument extends ArgumentResolver<CommandSender, Offli
     @SuppressWarnings("deprecation")
     @Override
     protected ParseResult<OfflinePlayer> parse(Invocation<CommandSender> invocation, Argument<OfflinePlayer> context, String argument) {
+        // TODO: Use async argument parsing: https://github.com/Rollczi/LiteCommands/pull/435
         if (enableThreadCheck && server.isPrimaryThread() && Instant.now().isAfter(nextWarningDate)) {
-            plugin.getLogger().warning("LiteCommands | OfflinePlayer argument resolved synchronously! This might cause server freeze!");
+            plugin.getLogger().warning("LiteCommands | OfflinePlayer argument resolved synchronously! This might cause server freeze! Add @Async to '" + context.getName() + "' argument. (command /" + invocation.name() + ")");
             nextWarningDate = Instant.now().plusSeconds(60);
         }
 
@@ -66,7 +62,21 @@ public class OfflinePlayerArgument extends ArgumentResolver<CommandSender, Offli
 
     @Override
     public SuggestionResult suggest(Invocation<CommandSender> invocation, Argument<OfflinePlayer> argument, SuggestionContext context) {
-        return SuggestionResult.of(nicknames);
+        if (nicknames.size() < SUGGESTION_LIMIT) {
+            return SuggestionResult.of(nicknames);
+        }
+
+        String input = context.getCurrent().multilevel();
+
+        if (input.isEmpty()) {
+            return nicknames.stream()
+                .limit(SUGGESTION_LIMIT)
+                .collect(SuggestionResult.collector());
+        }
+
+        return nicknames.subSet(input, input + Character.MAX_VALUE).stream()
+            .limit(SUGGESTION_LIMIT)
+            .collect(SuggestionResult.collector());
     }
 
 }

--- a/litecommands-bukkit/src/dev/rollczi/litecommands/bukkit/argument/OfflinePlayerArgument.java
+++ b/litecommands-bukkit/src/dev/rollczi/litecommands/bukkit/argument/OfflinePlayerArgument.java
@@ -1,0 +1,72 @@
+package dev.rollczi.litecommands.bukkit.argument;
+
+import com.google.common.collect.Sets;
+import dev.rollczi.litecommands.argument.Argument;
+import dev.rollczi.litecommands.argument.parser.ParseResult;
+import dev.rollczi.litecommands.argument.resolver.ArgumentResolver;
+import dev.rollczi.litecommands.bukkit.LiteBukkitMessages;
+import dev.rollczi.litecommands.invocation.Invocation;
+import dev.rollczi.litecommands.message.MessageRegistry;
+import dev.rollczi.litecommands.suggestion.SuggestionContext;
+import dev.rollczi.litecommands.suggestion.SuggestionResult;
+import org.bukkit.OfflinePlayer;
+import org.bukkit.Server;
+import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.player.PlayerJoinEvent;
+import org.bukkit.plugin.Plugin;
+
+import java.time.Instant;
+import java.util.Arrays;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+public class OfflinePlayerArgument extends ArgumentResolver<CommandSender, OfflinePlayer> {
+
+    private final Server server;
+    private final Plugin plugin;
+    private final boolean enableThreadCheck;
+
+    private final Set<String> nicknames = Sets.newConcurrentHashSet();
+    private Instant nextWarningDate = Instant.EPOCH;
+
+    public OfflinePlayerArgument(Server server, Plugin plugin, boolean enableThreadCheck) {
+        this.server = server;
+        this.plugin = plugin;
+        this.enableThreadCheck = enableThreadCheck;
+
+        // Server#getOfflinePlayers() can be blocking, so we don't want to call it every time
+        nicknames.addAll(
+            Arrays.stream(server.getOfflinePlayers())
+                .map(OfflinePlayer::getName)
+                .collect(Collectors.toList())
+        );
+
+        // Save new joining player names so our suggestions are more wide
+        server.getPluginManager().registerEvents(new Listener() {
+            @EventHandler
+            public void onPlayerJoin(PlayerJoinEvent event) {
+                nicknames.add(event.getPlayer().getName());
+            }
+        }, plugin);
+    }
+
+    @SuppressWarnings("deprecation")
+    @Override
+    protected ParseResult<OfflinePlayer> parse(Invocation<CommandSender> invocation, Argument<OfflinePlayer> context, String argument) {
+        if (enableThreadCheck && server.isPrimaryThread() && Instant.now().isAfter(nextWarningDate)) {
+            plugin.getLogger().warning("LiteCommands | OfflinePlayer argument resolved synchronously! This might cause server freeze!");
+            nextWarningDate = Instant.now().plusSeconds(60);
+        }
+
+        return ParseResult.success(server.getOfflinePlayer(argument));
+    }
+
+    @Override
+    public SuggestionResult suggest(Invocation<CommandSender> invocation, Argument<OfflinePlayer> argument, SuggestionContext context) {
+        return SuggestionResult.of(nicknames);
+    }
+
+}

--- a/litecommands-bukkit/src/dev/rollczi/litecommands/bukkit/util/BukkitFallbackPrefixUtil.java
+++ b/litecommands-bukkit/src/dev/rollczi/litecommands/bukkit/util/BukkitFallbackPrefixUtil.java
@@ -1,0 +1,20 @@
+package dev.rollczi.litecommands.bukkit.util;
+
+import java.util.Locale;
+import org.bukkit.plugin.Plugin;
+
+public final class BukkitFallbackPrefixUtil {
+
+    private BukkitFallbackPrefixUtil() {
+    }
+
+    public static String create(Plugin plugin) {
+        return create(plugin.getName());
+    }
+
+    public static String create(String name) {
+        return name.toLowerCase(Locale.ROOT)
+            .replace(" ", "-");
+    }
+
+}


### PR DESCRIPTION
Hi!

I improved `LiteBukkitFactory` by adding `build(Plugin)` method, `Plugin` bind and exposing `Plugin->fallbackPrefix` algorithm to public.

I added a very useful `OfflinePlayer` argument resolver. This time, a made it more smart that it's previous generations: now it checks and warns if called synchronously, as I noticed a lot of problems when using that in sync - this could not occur at testing time but sometimes just freezes the server in production, so we should prevent that softly. 

Also, now it collects as many nicknames as possible by caching player names, so suggestions should be much more useful than just `Server#getOnlinePlayers`.

Feel free to edit / request changes, as my style might be different from yours.

Also, I would be happy if you would make a release after merging that, so we can start using it. Thank you!