### PR TITLE
docs(README): Updated how to add LiteCommands dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,8 @@ maven("https://repo.panda-lang.org/releases")
 
 #### ➕ Add LiteCommands to dependencies
 ```kts
-implementation("dev.rollczi:{artifact}:3.9.1")
+modImplementation("dev.rollczi:{artifact}:3.9.1")
+// include modImplementation("dev.rollczi:{artifact}:3.9.1") < It will be included when build
 ```
 ```xml
 <dependency>


### PR DESCRIPTION
- Replaced implementation with modImplementation to accommodate changes in build systems
- Added a note stating that dependencies will be automatically included at build time and do not need to be added manually