### PR TITLE
GH-513 Add ConsoleOnlyContextProvider

### DIFF
--- a/litecommands-bukkit/src/dev/rollczi/litecommands/bukkit/LiteBukkitFactory.java
+++ b/litecommands-bukkit/src/dev/rollczi/litecommands/bukkit/LiteBukkitFactory.java
@@ -8,6 +8,7 @@ import dev.rollczi.litecommands.bukkit.argument.OldEnumAccessor;
 import dev.rollczi.litecommands.bukkit.argument.OldEnumArgument;
 import dev.rollczi.litecommands.bukkit.argument.PlayerArgument;
 import dev.rollczi.litecommands.bukkit.argument.WorldArgument;
+import dev.rollczi.litecommands.bukkit.context.ConsoleOnlyContextProvider;
 import dev.rollczi.litecommands.bukkit.context.LocationContext;
 import dev.rollczi.litecommands.bukkit.context.PlayerOnlyContextProvider;
 import dev.rollczi.litecommands.bukkit.context.WorldContext;
@@ -19,6 +20,7 @@ import org.bukkit.OfflinePlayer;
 import org.bukkit.Server;
 import org.bukkit.World;
 import org.bukkit.command.CommandSender;
+import org.bukkit.command.ConsoleCommandSender;
 import org.bukkit.entity.Player;
 import org.bukkit.plugin.Plugin;
 import org.bukkit.plugin.java.JavaPlugin;
@@ -74,6 +76,7 @@ public final class LiteBukkitFactory {
                 .argument(OfflinePlayer.class, new OfflinePlayerArgument(server, plugin, true))
 
                 .context(Player.class, new PlayerOnlyContextProvider(messageRegistry))
+                .context(ConsoleCommandSender.class, new ConsoleOnlyContextProvider(messageRegistry))
                 .context(World.class, new WorldContext(messageRegistry))
                 .context(Location.class, new LocationContext(messageRegistry))
 

--- a/litecommands-bukkit/src/dev/rollczi/litecommands/bukkit/LiteBukkitMessages.java
+++ b/litecommands-bukkit/src/dev/rollczi/litecommands/bukkit/LiteBukkitMessages.java
@@ -36,4 +36,9 @@ public class LiteBukkitMessages extends LiteMessages {
         unused -> "&cOnly player can execute this command! (PLAYER_ONLY)"
     );
 
+    public static final MessageKey<Void> CONSOLE_ONLY = MessageKey.of(
+        "only-console",
+        unused -> "&cOnly console can execute this command! (CONSOLE_ONLY)"
+    );
+
 }

--- a/litecommands-bukkit/src/dev/rollczi/litecommands/bukkit/context/ConsoleOnlyContextProvider.java
+++ b/litecommands-bukkit/src/dev/rollczi/litecommands/bukkit/context/ConsoleOnlyContextProvider.java
@@ -1,0 +1,29 @@
+package dev.rollczi.litecommands.bukkit.context;
+
+import dev.rollczi.litecommands.bukkit.LiteBukkitMessages;
+import dev.rollczi.litecommands.context.ContextProvider;
+import dev.rollczi.litecommands.context.ContextResult;
+import dev.rollczi.litecommands.invocation.Invocation;
+import dev.rollczi.litecommands.message.MessageRegistry;
+import org.bukkit.command.CommandSender;
+import org.bukkit.command.ConsoleCommandSender;
+import org.bukkit.entity.Player;
+
+public class ConsoleOnlyContextProvider implements ContextProvider<CommandSender, ConsoleCommandSender> {
+
+    private final MessageRegistry<CommandSender> messageRegistry;
+
+    public ConsoleOnlyContextProvider(MessageRegistry<CommandSender> messageRegistry) {
+        this.messageRegistry = messageRegistry;
+    }
+
+    @Override
+    public ContextResult<ConsoleCommandSender> provide(Invocation<CommandSender> invocation) {
+        if (invocation.sender() instanceof ConsoleCommandSender) {
+            return ContextResult.ok(() -> (ConsoleCommandSender) invocation.sender());
+        }
+
+        return ContextResult.error(messageRegistry.getInvoked(LiteBukkitMessages.CONSOLE_ONLY, invocation));
+    }
+
+}


### PR DESCRIPTION
Hey folks,

this PR adds a `ConsoleOnlyContextProvider` to the bukkit-platform, to be able to use bukkit's console sender as a context parameter instead of the `CommandSender` or a `Player`. 

It also adds the respective `MessageKey` as `LiteBukkitMessages.CONSOLE_ONLY`.