### PR TITLE
GH-516 Bump minestom and support only console context

### DIFF
--- a/buildSrc/src/main/kotlin/Versions.kt
+++ b/buildSrc/src/main/kotlin/Versions.kt
@@ -21,7 +21,7 @@ object Versions {
     const val JDA = "5.2.2"
 
     // Minestom
-    const val MINESTOM = "7320437640"
+    const val MINESTOM = "32735340d7"
 
     // Sponge
     const val SPONGE_API = "12.0.0"

--- a/examples/minestom/build.gradle.kts
+++ b/examples/minestom/build.gradle.kts
@@ -15,7 +15,7 @@ repositories {
 }
 
 dependencies {
-    implementation("net.minestom:minestom-snapshots:4305006e6b")
+    implementation("net.minestom:minestom-snapshots:32735340d7")
     implementation("net.kyori:adventure-text-minimessage:4.17.0")
 
     // implementation("dev.rollczi:litecommands-minestom:3.9.7") // <-- uncomment in your project

--- a/litecommands-bukkit/src/dev/rollczi/litecommands/bukkit/BukkitPlatform.java
+++ b/litecommands-bukkit/src/dev/rollczi/litecommands/bukkit/BukkitPlatform.java
@@ -1,13 +1,13 @@
 package dev.rollczi.litecommands.bukkit;
 
 import dev.rollczi.litecommands.command.CommandRoute;
-import dev.rollczi.litecommands.platform.AbstractPlatform;
+import dev.rollczi.litecommands.platform.AbstractSimplePlatform;
 import dev.rollczi.litecommands.platform.Platform;
 import dev.rollczi.litecommands.platform.PlatformInvocationListener;
 import dev.rollczi.litecommands.platform.PlatformSuggestionListener;
 import org.bukkit.command.CommandSender;
 
-class BukkitPlatform extends AbstractPlatform<CommandSender, LiteBukkitSettings> implements Platform<CommandSender, LiteBukkitSettings> {
+class BukkitPlatform extends AbstractSimplePlatform<CommandSender, LiteBukkitSettings> implements Platform<CommandSender, LiteBukkitSettings> {
 
     BukkitPlatform(LiteBukkitSettings settings) {
         super(settings, sender -> new BukkitPlatformSender(sender));

--- a/litecommands-bungee/src/dev/rollczi/litecommands/bungee/BungeePlatform.java
+++ b/litecommands-bungee/src/dev/rollczi/litecommands/bungee/BungeePlatform.java
@@ -1,7 +1,7 @@
 package dev.rollczi.litecommands.bungee;
 
 import dev.rollczi.litecommands.command.CommandRoute;
-import dev.rollczi.litecommands.platform.AbstractPlatform;
+import dev.rollczi.litecommands.platform.AbstractSimplePlatform;
 import dev.rollczi.litecommands.platform.PlatformInvocationListener;
 import dev.rollczi.litecommands.platform.PlatformSuggestionListener;
 import net.md_5.bungee.api.CommandSender;
@@ -13,7 +13,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
-class BungeePlatform extends AbstractPlatform<CommandSender, LiteBungeeSettings> {
+class BungeePlatform extends AbstractSimplePlatform<CommandSender, LiteBungeeSettings> {
 
     private final Plugin plugin;
     private final PluginManager pluginManager;

--- a/litecommands-core/src/dev/rollczi/litecommands/platform/AbstractPlatform.java
+++ b/litecommands-core/src/dev/rollczi/litecommands/platform/AbstractPlatform.java
@@ -9,12 +9,10 @@ import java.util.Map;
 public abstract class AbstractPlatform<SENDER, C extends PlatformSettings> implements Platform<SENDER, C> {
 
     protected @NotNull C settings;
-    protected final PlatformSenderFactory<SENDER> senderFactory;
     protected final Map<String, CommandRoute<SENDER>> commandRoutes = new HashMap<>();
 
-    protected AbstractPlatform(@NotNull C settings, PlatformSenderFactory<SENDER> senderFactory) {
+    protected AbstractPlatform(@NotNull C settings) {
         this.settings = settings;
-        this.senderFactory = senderFactory;
     }
 
     @Override
@@ -26,16 +24,6 @@ public abstract class AbstractPlatform<SENDER, C extends PlatformSettings> imple
     @NotNull
     public C getConfiguration() {
         return settings;
-    }
-
-    @Override
-    public PlatformSenderFactory<SENDER> getSenderFactory() {
-        return senderFactory;
-    }
-
-    @Override
-    public PlatformSender createSender(SENDER nativeSender) {
-        return this.getSenderFactory().create(nativeSender);
     }
 
     @Override

--- a/litecommands-core/src/dev/rollczi/litecommands/platform/AbstractSimplePlatform.java
+++ b/litecommands-core/src/dev/rollczi/litecommands/platform/AbstractSimplePlatform.java
@@ -1,0 +1,24 @@
+package dev.rollczi.litecommands.platform;
+
+import org.jetbrains.annotations.NotNull;
+
+public abstract class AbstractSimplePlatform<SENDER, C extends PlatformSettings> extends AbstractPlatform<SENDER, C> implements Platform<SENDER, C> {
+
+    protected final PlatformSenderFactory<SENDER> senderFactory;
+
+    protected AbstractSimplePlatform(@NotNull C settings, PlatformSenderFactory<SENDER> senderFactory) {
+        super(settings);
+        this.senderFactory = senderFactory;
+    }
+
+    @Override
+    public PlatformSender createSender(SENDER nativeSender) {
+        return senderFactory.create(nativeSender);
+    }
+
+    @Override
+    public PlatformSenderFactory<SENDER> getSenderFactory() {
+        return senderFactory;
+    }
+
+}

--- a/litecommands-fabric/src/main/java/dev/rollczi/litecommands/fabric/FabricAbstractPlatform.java
+++ b/litecommands-fabric/src/main/java/dev/rollczi/litecommands/fabric/FabricAbstractPlatform.java
@@ -4,7 +4,7 @@ import com.mojang.brigadier.CommandDispatcher;
 import com.mojang.brigadier.builder.LiteralArgumentBuilder;
 import com.mojang.brigadier.tree.LiteralCommandNode;
 import dev.rollczi.litecommands.command.CommandRoute;
-import dev.rollczi.litecommands.platform.AbstractPlatform;
+import dev.rollczi.litecommands.platform.AbstractSimplePlatform;
 import dev.rollczi.litecommands.platform.Platform;
 import dev.rollczi.litecommands.platform.PlatformInvocationListener;
 import dev.rollczi.litecommands.platform.PlatformSenderFactory;
@@ -14,7 +14,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.UUID;
 
-public abstract class FabricAbstractPlatform<SOURCE> extends AbstractPlatform<SOURCE, LiteFabricSettings> implements Platform<SOURCE, LiteFabricSettings> {
+public abstract class FabricAbstractPlatform<SOURCE> extends AbstractSimplePlatform<SOURCE, LiteFabricSettings> implements Platform<SOURCE, LiteFabricSettings> {
 
     protected final Map<UUID, FabricCommand<SOURCE>> fabricCommands = new HashMap<>();
 

--- a/litecommands-jda/src/dev/rollczi/litecommands/jda/JDAPlatform.java
+++ b/litecommands-jda/src/dev/rollczi/litecommands/jda/JDAPlatform.java
@@ -2,7 +2,7 @@ package dev.rollczi.litecommands.jda;
 
 import dev.rollczi.litecommands.command.CommandRoute;
 import dev.rollczi.litecommands.invocation.Invocation;
-import dev.rollczi.litecommands.platform.AbstractPlatform;
+import dev.rollczi.litecommands.platform.AbstractSimplePlatform;
 import dev.rollczi.litecommands.platform.PlatformInvocationListener;
 import dev.rollczi.litecommands.platform.PlatformSuggestionListener;
 import dev.rollczi.litecommands.suggestion.Suggestion;
@@ -25,7 +25,7 @@ import net.dv8tion.jda.api.interactions.commands.build.OptionData;
 import net.dv8tion.jda.api.interactions.commands.build.SlashCommandData;
 import org.jetbrains.annotations.Nullable;
 
-class JDAPlatform extends AbstractPlatform<User, LiteJDASettings> {
+class JDAPlatform extends AbstractSimplePlatform<User, LiteJDASettings> {
 
     private final JDA jda;
     private final Map<CommandRoute<User>, JDACommandRecord> commands = new HashMap<>();

--- a/litecommands-minestom/src/dev/rollczi/litecommands/minestom/LiteMinestomFactory.java
+++ b/litecommands-minestom/src/dev/rollczi/litecommands/minestom/LiteMinestomFactory.java
@@ -9,6 +9,7 @@ import dev.rollczi.litecommands.minestom.argument.PlayerArgument;
 import dev.rollczi.litecommands.minestom.context.ConsoleOnlyContextProvider;
 import dev.rollczi.litecommands.minestom.context.InstanceContextProvider;
 import dev.rollczi.litecommands.minestom.context.PlayerOnlyContextProvider;
+import dev.rollczi.litecommands.scheduler.SchedulerExecutorPoolImpl;
 import net.minestom.server.MinecraftServer;
 import net.minestom.server.command.CommandManager;
 import net.minestom.server.command.CommandSender;
@@ -44,7 +45,7 @@ public final class LiteMinestomFactory {
                 .extension(new LiteAdventureExtension<>(), configuration -> configuration
                     .legacyColor(true)
                 )
-                .scheduler(new MinestomScheduler(schedulerManager))
+                .scheduler(new MinestomScheduler(schedulerManager, new SchedulerExecutorPoolImpl("litecommands")))
                 .argument(Player.class, new PlayerArgument(connectionManager, messageRegistry))
                 .argument(Instance.class, new InstanceArgument(instanceManager, messageRegistry))
                 .context(Player.class, new PlayerOnlyContextProvider(messageRegistry))

--- a/litecommands-minestom/src/dev/rollczi/litecommands/minestom/LiteMinestomFactory.java
+++ b/litecommands-minestom/src/dev/rollczi/litecommands/minestom/LiteMinestomFactory.java
@@ -6,11 +6,13 @@ import dev.rollczi.litecommands.adventure.LiteAdventureExtension;
 import dev.rollczi.litecommands.message.MessageRegistry;
 import dev.rollczi.litecommands.minestom.argument.InstanceArgument;
 import dev.rollczi.litecommands.minestom.argument.PlayerArgument;
-import dev.rollczi.litecommands.minestom.context.InstanceContext;
-import dev.rollczi.litecommands.minestom.context.PlayerContext;
+import dev.rollczi.litecommands.minestom.context.ConsoleOnlyContextProvider;
+import dev.rollczi.litecommands.minestom.context.InstanceContextProvider;
+import dev.rollczi.litecommands.minestom.context.PlayerOnlyContextProvider;
 import net.minestom.server.MinecraftServer;
 import net.minestom.server.command.CommandManager;
 import net.minestom.server.command.CommandSender;
+import net.minestom.server.command.ConsoleSender;
 import net.minestom.server.entity.Player;
 import net.minestom.server.instance.Instance;
 import net.minestom.server.instance.InstanceManager;
@@ -45,8 +47,9 @@ public final class LiteMinestomFactory {
                 .scheduler(new MinestomScheduler(schedulerManager))
                 .argument(Player.class, new PlayerArgument(connectionManager, messageRegistry))
                 .argument(Instance.class, new InstanceArgument(instanceManager, messageRegistry))
-                .context(Player.class, new PlayerContext(messageRegistry))
-                .context(Instance.class, new InstanceContext(messageRegistry))
+                .context(Player.class, new PlayerOnlyContextProvider(messageRegistry))
+                .context(ConsoleSender.class, new ConsoleOnlyContextProvider(messageRegistry))
+                .context(Instance.class, new InstanceContextProvider(messageRegistry))
                 .bind(Server.class, () -> server);
         });
     }

--- a/litecommands-minestom/src/dev/rollczi/litecommands/minestom/LiteMinestomMessages.java
+++ b/litecommands-minestom/src/dev/rollczi/litecommands/minestom/LiteMinestomMessages.java
@@ -26,4 +26,9 @@ public class LiteMinestomMessages extends LiteMessages {
         unused -> "&cOnly player can execute this command! (PLAYER_ONLY)"
     );
 
+    public static final MessageKey<Void> CONSOLE_ONLY = MessageKey.of(
+        "only-player",
+        unused -> "&cOnly the console can execute this command! (CONSOLE_ONLY)"
+    );
+
 }

--- a/litecommands-minestom/src/dev/rollczi/litecommands/minestom/LiteMinestomSettings.java
+++ b/litecommands-minestom/src/dev/rollczi/litecommands/minestom/LiteMinestomSettings.java
@@ -1,7 +1,18 @@
 package dev.rollczi.litecommands.minestom;
 
+import dev.rollczi.litecommands.minestom.settings.PermissionResolver;
 import dev.rollczi.litecommands.platform.PlatformSettings;
 
 public class LiteMinestomSettings implements PlatformSettings {
 
+    private PermissionResolver permissionResolver;
+
+    public LiteMinestomSettings permissionResolver(PermissionResolver permissionResolver) {
+        this.permissionResolver = permissionResolver;
+        return this;
+    }
+
+    public PermissionResolver getPermissionResolver() {
+        return permissionResolver;
+    }
 }

--- a/litecommands-minestom/src/dev/rollczi/litecommands/minestom/LiteMinestomSettings.java
+++ b/litecommands-minestom/src/dev/rollczi/litecommands/minestom/LiteMinestomSettings.java
@@ -2,17 +2,19 @@ package dev.rollczi.litecommands.minestom;
 
 import dev.rollczi.litecommands.minestom.settings.PermissionResolver;
 import dev.rollczi.litecommands.platform.PlatformSettings;
+import net.minestom.server.command.CommandSender;
 
 public class LiteMinestomSettings implements PlatformSettings {
 
-    private PermissionResolver permissionResolver;
+    private PermissionResolver permissionResolver = (sender, permission) -> true;
 
     public LiteMinestomSettings permissionResolver(PermissionResolver permissionResolver) {
         this.permissionResolver = permissionResolver;
         return this;
     }
 
-    public PermissionResolver getPermissionResolver() {
-        return permissionResolver;
+    boolean hasPermission(CommandSender handle, String permission) {
+        return permissionResolver.hasPermission(handle, permission);
     }
+
 }

--- a/litecommands-minestom/src/dev/rollczi/litecommands/minestom/MinestomCommand.java
+++ b/litecommands-minestom/src/dev/rollczi/litecommands/minestom/MinestomCommand.java
@@ -20,12 +20,14 @@ import java.util.Set;
 
 class MinestomCommand extends Command {
 
+    private final MinestomPlatform platform;
     private final CommandRoute<CommandSender> command;
     private final PlatformInvocationListener<CommandSender> invocationHook;
     private final PlatformSuggestionListener<CommandSender> suggestionListener;
 
-    MinestomCommand(CommandRoute<CommandSender> command, PlatformInvocationListener<CommandSender> invocationHook, PlatformSuggestionListener<CommandSender> suggestionListener) {
+    MinestomCommand(MinestomPlatform platform, CommandRoute<CommandSender> command, PlatformInvocationListener<CommandSender> invocationHook, PlatformSuggestionListener<CommandSender> suggestionListener) {
         super(command.getName(), command.getAliases().toArray(new String[0]));
+        this.platform = platform;
         this.command = command;
         this.invocationHook = invocationHook;
         this.suggestionListener = suggestionListener;
@@ -74,7 +76,9 @@ class MinestomCommand extends Command {
     }
 
     private Invocation<CommandSender> createInvocation(CommandSender sender, String alias, Input<?> input) {
-        return new Invocation<>(sender, new MinestomSender(sender), this.command.getName(), alias, input);
+        MinestomSender minestomSender = new MinestomSender(sender);
+        minestomSender.setPlatform(platform);
+        return new Invocation<>(sender, minestomSender, this.command.getName(), alias, input);
     }
 
     private String[] fixArguments(String[] args) {

--- a/litecommands-minestom/src/dev/rollczi/litecommands/minestom/MinestomCommand.java
+++ b/litecommands-minestom/src/dev/rollczi/litecommands/minestom/MinestomCommand.java
@@ -76,9 +76,7 @@ class MinestomCommand extends Command {
     }
 
     private Invocation<CommandSender> createInvocation(CommandSender sender, String alias, Input<?> input) {
-        MinestomSender minestomSender = new MinestomSender(sender);
-        minestomSender.setPlatform(platform);
-        return new Invocation<>(sender, minestomSender, this.command.getName(), alias, input);
+        return new Invocation<>(sender, platform.createSender(sender), this.command.getName(), alias, input);
     }
 
     private String[] fixArguments(String[] args) {

--- a/litecommands-minestom/src/dev/rollczi/litecommands/minestom/MinestomPlatform.java
+++ b/litecommands-minestom/src/dev/rollczi/litecommands/minestom/MinestomPlatform.java
@@ -3,6 +3,7 @@ package dev.rollczi.litecommands.minestom;
 import dev.rollczi.litecommands.command.CommandRoute;
 import dev.rollczi.litecommands.platform.AbstractPlatform;
 import dev.rollczi.litecommands.platform.PlatformInvocationListener;
+import dev.rollczi.litecommands.platform.PlatformSender;
 import dev.rollczi.litecommands.platform.PlatformSuggestionListener;
 import net.minestom.server.command.CommandManager;
 import net.minestom.server.command.CommandSender;
@@ -35,8 +36,15 @@ class MinestomPlatform extends AbstractPlatform<CommandSender, LiteMinestomSetti
         this.commandManager.unregister(commandToDelete);
     }
 
+    @Override
+    public PlatformSender createSender(CommandSender nativeSender) {
+        MinestomSender minestomSender = (MinestomSender) super.createSender(nativeSender);
+        minestomSender.setPlatform(this);
+        return minestomSender;
+    }
+
     private MinestomCommand createCommand(CommandRoute<CommandSender> command, PlatformInvocationListener<CommandSender> invocationHook, PlatformSuggestionListener<CommandSender> suggestionHook) {
-        return new MinestomCommand(command, invocationHook, suggestionHook);
+        return new MinestomCommand(this, command, invocationHook, suggestionHook);
     }
 
 }

--- a/litecommands-minestom/src/dev/rollczi/litecommands/minestom/MinestomPlatform.java
+++ b/litecommands-minestom/src/dev/rollczi/litecommands/minestom/MinestomPlatform.java
@@ -4,6 +4,7 @@ import dev.rollczi.litecommands.command.CommandRoute;
 import dev.rollczi.litecommands.platform.AbstractPlatform;
 import dev.rollczi.litecommands.platform.PlatformInvocationListener;
 import dev.rollczi.litecommands.platform.PlatformSender;
+import dev.rollczi.litecommands.platform.PlatformSenderFactory;
 import dev.rollczi.litecommands.platform.PlatformSuggestionListener;
 import net.minestom.server.command.CommandManager;
 import net.minestom.server.command.CommandSender;
@@ -14,7 +15,7 @@ class MinestomPlatform extends AbstractPlatform<CommandSender, LiteMinestomSetti
     private final CommandManager commandManager;
 
     MinestomPlatform(CommandManager commandManager) {
-        super(new LiteMinestomSettings(), sender -> new MinestomSender(sender));
+        super(new LiteMinestomSettings());
         this.commandManager = commandManager;
     }
 
@@ -37,10 +38,13 @@ class MinestomPlatform extends AbstractPlatform<CommandSender, LiteMinestomSetti
     }
 
     @Override
+    public PlatformSenderFactory<CommandSender> getSenderFactory() {
+        return commandSender -> createSender(commandSender);
+    }
+
+    @Override
     public PlatformSender createSender(CommandSender nativeSender) {
-        MinestomSender minestomSender = (MinestomSender) super.createSender(nativeSender);
-        minestomSender.setPlatform(this);
-        return minestomSender;
+        return new MinestomSender(nativeSender, this);
     }
 
     private MinestomCommand createCommand(CommandRoute<CommandSender> command, PlatformInvocationListener<CommandSender> invocationHook, PlatformSuggestionListener<CommandSender> suggestionHook) {

--- a/litecommands-minestom/src/dev/rollczi/litecommands/minestom/MinestomScheduler.java
+++ b/litecommands-minestom/src/dev/rollczi/litecommands/minestom/MinestomScheduler.java
@@ -12,9 +12,11 @@ import net.minestom.server.timer.Task;
 public class MinestomScheduler implements Scheduler {
 
     private final SchedulerManager scheduler;
+    private final Scheduler asyncScheduler;
 
-    public MinestomScheduler(SchedulerManager scheduler) {
+    public MinestomScheduler(SchedulerManager scheduler, Scheduler asyncScheduler) {
         this.scheduler = scheduler;
+        this.asyncScheduler = asyncScheduler;
     }
 
     @Override
@@ -22,17 +24,26 @@ public class MinestomScheduler implements Scheduler {
         SchedulerPoll poll = type.resolve(SchedulerPoll.MAIN, SchedulerPoll.ASYNCHRONOUS);
         CompletableFuture<T> future = new CompletableFuture<>();
 
-        // ExecutionType changes, deprecation warnings suggestions:
-        // https://github.com/Minestom/Minestom/commit/a9f6d9f02b0e90e0936a2c684e17cbbfd3264dd5
-        Task.Builder built = scheduler.buildTask(() -> tryRun(supplier, future))
-            .executionType(poll == SchedulerPoll.MAIN ? ExecutionType.TICK_START : ExecutionType.TICK_END);
+        if (poll == SchedulerPoll.MAIN || poll == MinestomSchedulerPoll.TICK_START || poll == MinestomSchedulerPoll.TICK_END) {
+            Task.Builder built = scheduler.buildTask(() -> tryRun(supplier, future));
 
-        if (!delay.isZero()) {
-            built.delay(delay);
+            if (!delay.isZero()) {
+                built.delay(delay);
+            }
+
+            if (poll == MinestomSchedulerPoll.TICK_START) {
+                built.executionType(ExecutionType.TICK_START);
+            }
+
+            if (poll == MinestomSchedulerPoll.TICK_END) {
+                built.executionType(ExecutionType.TICK_END);
+            }
+
+            built.schedule();
+            return future;
         }
 
-        built.schedule();
-        return future;
+        return asyncScheduler.supplyLater(SchedulerPoll.ASYNCHRONOUS, delay, supplier);
     }
 
     @Override

--- a/litecommands-minestom/src/dev/rollczi/litecommands/minestom/MinestomScheduler.java
+++ b/litecommands-minestom/src/dev/rollczi/litecommands/minestom/MinestomScheduler.java
@@ -22,8 +22,10 @@ public class MinestomScheduler implements Scheduler {
         SchedulerPoll poll = type.resolve(SchedulerPoll.MAIN, SchedulerPoll.ASYNCHRONOUS);
         CompletableFuture<T> future = new CompletableFuture<>();
 
+        // ExecutionType changes, deprecation warnings suggestions:
+        // https://github.com/Minestom/Minestom/commit/a9f6d9f02b0e90e0936a2c684e17cbbfd3264dd5
         Task.Builder built = scheduler.buildTask(() -> tryRun(supplier, future))
-            .executionType(poll == SchedulerPoll.MAIN ? ExecutionType.SYNC : ExecutionType.ASYNC);
+            .executionType(poll == SchedulerPoll.MAIN ? ExecutionType.TICK_START : ExecutionType.TICK_END);
 
         if (!delay.isZero()) {
             built.delay(delay);

--- a/litecommands-minestom/src/dev/rollczi/litecommands/minestom/MinestomSchedulerPoll.java
+++ b/litecommands-minestom/src/dev/rollczi/litecommands/minestom/MinestomSchedulerPoll.java
@@ -1,0 +1,18 @@
+package dev.rollczi.litecommands.minestom;
+
+import dev.rollczi.litecommands.scheduler.SchedulerPoll;
+
+public class MinestomSchedulerPoll extends SchedulerPoll {
+
+    protected MinestomSchedulerPoll(String name, SchedulerPoll... replaceable) {
+        super(name, replaceable);
+    }
+
+    protected MinestomSchedulerPoll(String name, boolean logging, SchedulerPoll... replaceable) {
+        super(name, logging, replaceable);
+    }
+
+    public static final MinestomSchedulerPoll TICK_START = new MinestomSchedulerPoll("main_tick_start", SchedulerPoll.MAIN);
+    public static final MinestomSchedulerPoll TICK_END = new MinestomSchedulerPoll("main_tick_end", SchedulerPoll.MAIN);
+
+}

--- a/litecommands-minestom/src/dev/rollczi/litecommands/minestom/MinestomSender.java
+++ b/litecommands-minestom/src/dev/rollczi/litecommands/minestom/MinestomSender.java
@@ -1,6 +1,7 @@
 package dev.rollczi.litecommands.minestom;
 
 import dev.rollczi.litecommands.identifier.Identifier;
+import dev.rollczi.litecommands.minestom.settings.PermissionResolver;
 import dev.rollczi.litecommands.platform.AbstractPlatformSender;
 import dev.rollczi.litecommands.platform.PlatformSender;
 import net.minestom.server.command.CommandSender;
@@ -8,17 +9,34 @@ import net.minestom.server.command.ConsoleSender;
 import net.minestom.server.command.ServerSender;
 import net.minestom.server.entity.Player;
 
+import java.util.function.BiFunction;
+
 class MinestomSender extends AbstractPlatformSender {
 
     private final CommandSender handle;
+    private MinestomPlatform platform;
 
     public MinestomSender(CommandSender handle) {
         this.handle = handle;
     }
 
+    public void setPlatform(MinestomPlatform platform) {
+        // We can't pass the platform directly into the constructor,
+        // because the sender factory isn't able to access the platform instance
+        // in the super constructor call of the platform itself.
+        this.platform = platform;
+    }
+
     @Override
     public boolean hasPermission(String permission) {
-        return this.handle.hasPermission(permission);
+        if(this.platform == null) {
+            throw new NullPointerException("MinestomPlatform not set");
+        }
+        PermissionResolver permissionResolver = this.platform.getConfiguration().getPermissionResolver();
+        if(permission == null) {
+            return true;
+        }
+        return permissionResolver.hasPermission(this.handle, permission);
     }
 
     @Override

--- a/litecommands-minestom/src/dev/rollczi/litecommands/minestom/MinestomSender.java
+++ b/litecommands-minestom/src/dev/rollczi/litecommands/minestom/MinestomSender.java
@@ -1,42 +1,26 @@
 package dev.rollczi.litecommands.minestom;
 
 import dev.rollczi.litecommands.identifier.Identifier;
-import dev.rollczi.litecommands.minestom.settings.PermissionResolver;
 import dev.rollczi.litecommands.platform.AbstractPlatformSender;
-import dev.rollczi.litecommands.platform.PlatformSender;
+import net.kyori.adventure.pointer.Pointer;
 import net.minestom.server.command.CommandSender;
 import net.minestom.server.command.ConsoleSender;
 import net.minestom.server.command.ServerSender;
 import net.minestom.server.entity.Player;
 
-import java.util.function.BiFunction;
-
 class MinestomSender extends AbstractPlatformSender {
 
     private final CommandSender handle;
-    private MinestomPlatform platform;
+    private final MinestomPlatform platform;
 
-    public MinestomSender(CommandSender handle) {
+    public MinestomSender(CommandSender handle, MinestomPlatform platform) {
         this.handle = handle;
-    }
-
-    public void setPlatform(MinestomPlatform platform) {
-        // We can't pass the platform directly into the constructor,
-        // because the sender factory isn't able to access the platform instance
-        // in the super constructor call of the platform itself.
         this.platform = platform;
     }
 
     @Override
     public boolean hasPermission(String permission) {
-        if(this.platform == null) {
-            throw new NullPointerException("MinestomPlatform not set");
-        }
-        PermissionResolver permissionResolver = this.platform.getConfiguration().getPermissionResolver();
-        if(permission == null) {
-            return true;
-        }
-        return permissionResolver.hasPermission(this.handle, permission);
+        return this.platform.getConfiguration().hasPermission(this.handle, permission);
     }
 
     @Override

--- a/litecommands-minestom/src/dev/rollczi/litecommands/minestom/context/ConsoleOnlyContextProvider.java
+++ b/litecommands-minestom/src/dev/rollczi/litecommands/minestom/context/ConsoleOnlyContextProvider.java
@@ -1,0 +1,30 @@
+package dev.rollczi.litecommands.minestom.context;
+
+import dev.rollczi.litecommands.context.ContextProvider;
+import dev.rollczi.litecommands.context.ContextResult;
+import dev.rollczi.litecommands.invocation.Invocation;
+import dev.rollczi.litecommands.message.MessageRegistry;
+import dev.rollczi.litecommands.minestom.LiteMinestomMessages;
+import net.minestom.server.command.CommandSender;
+import net.minestom.server.command.ConsoleSender;
+
+public class ConsoleOnlyContextProvider implements ContextProvider<CommandSender, ConsoleSender> {
+
+    private final MessageRegistry<CommandSender> messageRegistry;
+
+    public ConsoleOnlyContextProvider(MessageRegistry<CommandSender> messageRegistry) {
+        this.messageRegistry = messageRegistry;
+    }
+
+    @Override
+    public ContextResult<ConsoleSender> provide(Invocation<CommandSender> invocation) {
+        CommandSender sender = invocation.sender();
+
+        if (sender instanceof ConsoleSender console) {
+            return ContextResult.ok(() -> console);
+        }
+
+        return ContextResult.error(messageRegistry.getInvoked(LiteMinestomMessages.CONSOLE_ONLY, invocation));
+    }
+
+}

--- a/litecommands-minestom/src/dev/rollczi/litecommands/minestom/context/InstanceContextProvider.java
+++ b/litecommands-minestom/src/dev/rollczi/litecommands/minestom/context/InstanceContextProvider.java
@@ -9,11 +9,11 @@ import net.minestom.server.command.CommandSender;
 import net.minestom.server.entity.Player;
 import net.minestom.server.instance.Instance;
 
-public class InstanceContext implements ContextProvider<CommandSender, Instance> {
+public class InstanceContextProvider implements ContextProvider<CommandSender, Instance> {
 
     private final MessageRegistry<CommandSender> messageRegistry;
 
-    public InstanceContext(MessageRegistry<CommandSender> messageRegistry) {
+    public InstanceContextProvider(MessageRegistry<CommandSender> messageRegistry) {
         this.messageRegistry = messageRegistry;
     }
 

--- a/litecommands-minestom/src/dev/rollczi/litecommands/minestom/context/PlayerOnlyContextProvider.java
+++ b/litecommands-minestom/src/dev/rollczi/litecommands/minestom/context/PlayerOnlyContextProvider.java
@@ -8,11 +8,11 @@ import dev.rollczi.litecommands.minestom.LiteMinestomMessages;
 import net.minestom.server.command.CommandSender;
 import net.minestom.server.entity.Player;
 
-public class PlayerContext implements ContextProvider<CommandSender, Player> {
+public class PlayerOnlyContextProvider implements ContextProvider<CommandSender, Player> {
 
     private final MessageRegistry<CommandSender> messageRegistry;
 
-    public PlayerContext(MessageRegistry<CommandSender> messageRegistry) {
+    public PlayerOnlyContextProvider(MessageRegistry<CommandSender> messageRegistry) {
         this.messageRegistry = messageRegistry;
     }
 

--- a/litecommands-minestom/src/dev/rollczi/litecommands/minestom/settings/PermissionResolver.java
+++ b/litecommands-minestom/src/dev/rollczi/litecommands/minestom/settings/PermissionResolver.java
@@ -1,0 +1,9 @@
+package dev.rollczi.litecommands.minestom.settings;
+
+import net.minestom.server.command.CommandSender;
+
+@FunctionalInterface
+public interface PermissionResolver {
+
+    boolean hasPermission(CommandSender sender, String permission);
+}

--- a/litecommands-minestom/src/dev/rollczi/litecommands/minestom/settings/PermissionResolver.java
+++ b/litecommands-minestom/src/dev/rollczi/litecommands/minestom/settings/PermissionResolver.java
@@ -6,4 +6,5 @@ import net.minestom.server.command.CommandSender;
 public interface PermissionResolver {
 
     boolean hasPermission(CommandSender sender, String permission);
+
 }

--- a/litecommands-minestom/test/dev/rollczi/litecommands/minestom/MineStomIntegrationSpec.java
+++ b/litecommands-minestom/test/dev/rollczi/litecommands/minestom/MineStomIntegrationSpec.java
@@ -9,6 +9,7 @@ import net.minestom.server.command.CommandSender;
 import net.minestom.server.command.ConsoleSender;
 import net.minestom.server.entity.Player;
 import net.minestom.server.network.ConnectionManager;
+import net.minestom.server.network.player.GameProfile;
 import net.minestom.server.timer.SchedulerManager;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
@@ -48,7 +49,8 @@ public class MineStomIntegrationSpec {
             commands.put(field, command);
         }
 
-        MinecraftServer.getConnectionManager().setPlayerProvider((uuid, s, playerConnection) -> new TestPlayer(uuid, s));
+        MinecraftServer.getConnectionManager().setPlayerProvider(
+            (connection, gameProfile) -> new TestPlayer(connection, gameProfile));
 
         liteCommands = LiteMinestomFactory.builder()
             .commands(commands.values().toArray())
@@ -68,7 +70,8 @@ public class MineStomIntegrationSpec {
 
     protected static TestPlayer player(String name) {
         ConnectionManager connectionManager = MinecraftServer.getConnectionManager();
-        Player player = connectionManager.createPlayer(new TestPlayerConnection(), UUID.nameUUIDFromBytes(name.getBytes()), name);
+        GameProfile gameProfile = new GameProfile(UUID.nameUUIDFromBytes(name.getBytes()), name);
+        Player player = connectionManager.createPlayer(new TestPlayerConnection(), gameProfile);
         connectionManager.transitionConfigToPlay(player);
         connectionManager.tick(0);
 

--- a/litecommands-minestom/test/dev/rollczi/litecommands/minestom/MineStomIntegrationSpec.java
+++ b/litecommands-minestom/test/dev/rollczi/litecommands/minestom/MineStomIntegrationSpec.java
@@ -30,6 +30,7 @@ public class MineStomIntegrationSpec {
 
     @BeforeAll
     static void beforeAll(TestInfo testInfo) throws ReflectiveOperationException {
+        System.setProperty("minestom.inside-test", "true");
         minecraftServer = MinecraftServer.init();
 
         Class<?> type =  testInfo.getTestClass().orElseThrow();

--- a/litecommands-minestom/test/dev/rollczi/litecommands/minestom/test/TestPlayer.java
+++ b/litecommands-minestom/test/dev/rollczi/litecommands/minestom/test/TestPlayer.java
@@ -9,6 +9,8 @@ import net.kyori.adventure.identity.Identity;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.TextComponent;
 import net.minestom.server.entity.Player;
+import net.minestom.server.network.player.GameProfile;
+import net.minestom.server.network.player.PlayerConnection;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.UUID;
@@ -17,8 +19,8 @@ public class TestPlayer extends Player {
 
     private final List<Object> messages = new ArrayList<>();
 
-    public TestPlayer(@NotNull UUID uuid, @NotNull String username) {
-        super(uuid, username, new TestPlayerConnection());
+    public TestPlayer(@NotNull PlayerConnection connection, @NotNull GameProfile profile) {
+        super(connection, profile);
     }
 
     @Override

--- a/litecommands-sponge/src/dev/rollczi/litecommands/sponge/SpongePlatform.java
+++ b/litecommands-sponge/src/dev/rollczi/litecommands/sponge/SpongePlatform.java
@@ -1,7 +1,7 @@
 package dev.rollczi.litecommands.sponge;
 
 import dev.rollczi.litecommands.command.CommandRoute;
-import dev.rollczi.litecommands.platform.AbstractPlatform;
+import dev.rollczi.litecommands.platform.AbstractSimplePlatform;
 import dev.rollczi.litecommands.platform.PlatformInvocationListener;
 import dev.rollczi.litecommands.platform.PlatformSuggestionListener;
 import java.util.HashMap;
@@ -14,7 +14,7 @@ import org.spongepowered.api.event.Listener;
 import org.spongepowered.api.event.lifecycle.RegisterCommandEvent;
 import org.spongepowered.plugin.PluginContainer;
 
-public class SpongePlatform extends AbstractPlatform<CommandCause, LiteSpongeSettings> {
+public class SpongePlatform extends AbstractSimplePlatform<CommandCause, LiteSpongeSettings> {
 
     private final PluginContainer plugin;
     private final Map<UUID, SpongeCommand> commands = new HashMap<>();

--- a/litecommands-unit/src/dev/rollczi/litecommands/unit/TestPlatform.java
+++ b/litecommands-unit/src/dev/rollczi/litecommands/unit/TestPlatform.java
@@ -4,7 +4,7 @@ import dev.rollczi.litecommands.command.CommandRoute;
 import dev.rollczi.litecommands.argument.parser.input.ParseableInput;
 import dev.rollczi.litecommands.input.raw.RawCommand;
 import dev.rollczi.litecommands.invocation.Invocation;
-import dev.rollczi.litecommands.platform.AbstractPlatform;
+import dev.rollczi.litecommands.platform.AbstractSimplePlatform;
 import dev.rollczi.litecommands.platform.PlatformInvocationListener;
 import dev.rollczi.litecommands.platform.PlatformSender;
 import dev.rollczi.litecommands.platform.PlatformSuggestionListener;
@@ -17,7 +17,7 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
-public class TestPlatform extends AbstractPlatform<TestSender, TestSettings> {
+public class TestPlatform extends AbstractSimplePlatform<TestSender, TestSettings> {
 
     private static final TestPlatformSender DEFAULT_SENDER = new TestPlatformSender();
     private final Map<CommandRoute<TestSender>, PlatformInvocationListener<TestSender>> executeListeners = new LinkedHashMap<>();

--- a/litecommands-velocity/src/dev/rollczi/litecommands/velocity/VelocityPlatform.java
+++ b/litecommands-velocity/src/dev/rollczi/litecommands/velocity/VelocityPlatform.java
@@ -4,11 +4,11 @@ import com.velocitypowered.api.command.CommandManager;
 import com.velocitypowered.api.command.CommandMeta;
 import com.velocitypowered.api.command.CommandSource;
 import dev.rollczi.litecommands.command.CommandRoute;
-import dev.rollczi.litecommands.platform.AbstractPlatform;
+import dev.rollczi.litecommands.platform.AbstractSimplePlatform;
 import dev.rollczi.litecommands.platform.PlatformInvocationListener;
 import dev.rollczi.litecommands.platform.PlatformSuggestionListener;
 
-class VelocityPlatform extends AbstractPlatform<CommandSource, LiteVelocitySettings> {
+class VelocityPlatform extends AbstractSimplePlatform<CommandSource, LiteVelocitySettings> {
 
     private final CommandManager commandManager;
 


### PR DESCRIPTION
Hey folks,

this PR updates `litecommands-minestom` to the latest snapshot version `32735340d7`.

Furthermore I created a `PermissionResolver` and added it as setting to `LiteMinestomSettings`. It's just an interface, which enables the user to check the permissions by himself instead of relying on minestom's api. Minestom itself removed it's permission support and only provides a permission level on the their `Player` but this permission level can't be used for "traditional" permission checking.

It also adds a `ConsoleOnlyContextProvider`.