### PR TITLE
GH-534 Support retrieve context objects from all entities and command blocks

### DIFF
--- a/litecommands-bukkit/src/dev/rollczi/litecommands/bukkit/LiteBukkitMessages.java
+++ b/litecommands-bukkit/src/dev/rollczi/litecommands/bukkit/LiteBukkitMessages.java
@@ -28,6 +28,11 @@ public class LiteBukkitMessages extends LiteMessages {
         unused -> "&cOnly player can execute this command! (WORLD_PLAYER_ONLY)"
     ).withFallbacks(PLAYER_ONLY);
 
+    public static final MessageKey<Void> WORLD_NON_CONSOLE_ONLY = MessageKey.of(
+        "location-non-console-only",
+        unused -> "&cConsole cannot execute this command! (WORLD_NON_CONSOLE_ONLY)"
+    );
+
     public static final MessageKey<String> LOCATION_INVALID_FORMAT = MessageKey.of(
         "location-invalid-format",
         input -> "&cInvalid location format '" + input + "'! Use: <x> <y> <z> (LOCATION_INVALID_FORMAT)"
@@ -37,6 +42,11 @@ public class LiteBukkitMessages extends LiteMessages {
         "location-player-only",
         unused -> "&cOnly player can execute this command! (LOCATION_PLAYER_ONLY)"
     ).withFallbacks(PLAYER_ONLY);
+
+    public static final MessageKey<Void> LOCATION_NON_CONSOLE_ONLY = MessageKey.of(
+        "location-player-only",
+        unused -> "&cConsole cannot execute this command! (LOCATION_NON_CONSOLE_ONLY)"
+    );
 
     public static final MessageKey<String> PLAYER_NOT_FOUND = MessageKey.of(
         "player-not-found",

--- a/litecommands-bukkit/src/dev/rollczi/litecommands/bukkit/LiteBukkitMessages.java
+++ b/litecommands-bukkit/src/dev/rollczi/litecommands/bukkit/LiteBukkitMessages.java
@@ -2,9 +2,6 @@ package dev.rollczi.litecommands.bukkit;
 
 import dev.rollczi.litecommands.message.LiteMessages;
 import dev.rollczi.litecommands.message.MessageKey;
-import java.util.Arrays;
-import java.util.List;
-import org.bukkit.command.CommandSender;
 
 public class LiteBukkitMessages extends LiteMessages {
 
@@ -23,30 +20,32 @@ public class LiteBukkitMessages extends LiteMessages {
         input -> "&cWorld " + input + " doesn't exist! (WORLD_NOT_EXIST)"
     );
 
+    @Deprecated
     public static final MessageKey<Void> WORLD_PLAYER_ONLY = MessageKey.<Void>of(
         "world-player-only",
         unused -> "&cOnly player can execute this command! (WORLD_PLAYER_ONLY)"
     ).withFallbacks(PLAYER_ONLY);
 
-    public static final MessageKey<Void> WORLD_NON_CONSOLE_ONLY = MessageKey.of(
-        "location-non-console-only",
-        unused -> "&cConsole cannot execute this command! (WORLD_NON_CONSOLE_ONLY)"
-    );
+    public static final MessageKey<Void> WORLD_NO_CONSOLE = MessageKey.<Void>of(
+        "world-no-console",
+        unused -> "&cConsole cannot execute this command! (WORLD_NO_CONSOLE)"
+    ).withFallbacks(WORLD_PLAYER_ONLY, PLAYER_ONLY);
 
     public static final MessageKey<String> LOCATION_INVALID_FORMAT = MessageKey.of(
         "location-invalid-format",
         input -> "&cInvalid location format '" + input + "'! Use: <x> <y> <z> (LOCATION_INVALID_FORMAT)"
     );
 
+    @Deprecated
     public static final MessageKey<Void> LOCATION_PLAYER_ONLY = MessageKey.<Void>of(
         "location-player-only",
         unused -> "&cOnly player can execute this command! (LOCATION_PLAYER_ONLY)"
     ).withFallbacks(PLAYER_ONLY);
 
-    public static final MessageKey<Void> LOCATION_NON_CONSOLE_ONLY = MessageKey.of(
-        "location-player-only",
-        unused -> "&cConsole cannot execute this command! (LOCATION_NON_CONSOLE_ONLY)"
-    );
+    public static final MessageKey<Void> LOCATION_NO_CONSOLE = MessageKey.<Void>of(
+        "location-no-console",
+        unused -> "&cConsole cannot execute this command! (LOCATION_NO_CONSOLE)"
+    ).withFallbacks(LOCATION_PLAYER_ONLY, PLAYER_ONLY);
 
     public static final MessageKey<String> PLAYER_NOT_FOUND = MessageKey.of(
         "player-not-found",

--- a/litecommands-bukkit/src/dev/rollczi/litecommands/bukkit/context/LocationContext.java
+++ b/litecommands-bukkit/src/dev/rollczi/litecommands/bukkit/context/LocationContext.java
@@ -32,7 +32,7 @@ public class LocationContext implements ContextProvider<CommandSender, Location>
             return ContextResult.ok(() -> blockCommandSender.getBlock().getLocation());
         }
 
-        return ContextResult.error(messageRegistry.get(LiteBukkitMessages.LOCATION_NON_CONSOLE_ONLY, invocation));
+        return ContextResult.error(messageRegistry.get(LiteBukkitMessages.LOCATION_NO_CONSOLE, invocation));
     }
 
 }

--- a/litecommands-bukkit/src/dev/rollczi/litecommands/bukkit/context/LocationContext.java
+++ b/litecommands-bukkit/src/dev/rollczi/litecommands/bukkit/context/LocationContext.java
@@ -6,8 +6,9 @@ import dev.rollczi.litecommands.context.ContextResult;
 import dev.rollczi.litecommands.invocation.Invocation;
 import dev.rollczi.litecommands.message.MessageRegistry;
 import org.bukkit.Location;
+import org.bukkit.command.BlockCommandSender;
 import org.bukkit.command.CommandSender;
-import org.bukkit.entity.Player;
+import org.bukkit.entity.Entity;
 
 public class LocationContext implements ContextProvider<CommandSender, Location> {
 
@@ -21,13 +22,17 @@ public class LocationContext implements ContextProvider<CommandSender, Location>
     public ContextResult<Location> provide(Invocation<CommandSender> invocation) {
         CommandSender sender = invocation.sender();
 
-        if (sender instanceof Player) {
-            Player player = (Player) sender;
+        if (sender instanceof Entity) {
+            Entity entity = (Entity) sender;
 
-            return ContextResult.ok(() -> player.getLocation());
+            return ContextResult.ok(() -> entity.getLocation());
+        } else if (sender instanceof BlockCommandSender) {
+            BlockCommandSender blockCommandSender = (BlockCommandSender) sender;
+
+            return ContextResult.ok(() -> blockCommandSender.getBlock().getLocation());
         }
 
-        return ContextResult.error(messageRegistry.get(LiteBukkitMessages.LOCATION_PLAYER_ONLY, invocation));
+        return ContextResult.error(messageRegistry.get(LiteBukkitMessages.LOCATION_NON_CONSOLE_ONLY, invocation));
     }
 
 }

--- a/litecommands-bukkit/src/dev/rollczi/litecommands/bukkit/context/WorldContext.java
+++ b/litecommands-bukkit/src/dev/rollczi/litecommands/bukkit/context/WorldContext.java
@@ -6,8 +6,9 @@ import dev.rollczi.litecommands.context.ContextResult;
 import dev.rollczi.litecommands.invocation.Invocation;
 import dev.rollczi.litecommands.message.MessageRegistry;
 import org.bukkit.World;
+import org.bukkit.command.BlockCommandSender;
 import org.bukkit.command.CommandSender;
-import org.bukkit.entity.Player;
+import org.bukkit.entity.Entity;
 
 public class WorldContext implements ContextProvider<CommandSender, World> {
 
@@ -21,13 +22,17 @@ public class WorldContext implements ContextProvider<CommandSender, World> {
     public ContextResult<World> provide(Invocation<CommandSender> invocation) {
         CommandSender sender = invocation.sender();
 
-        if (sender instanceof Player) {
-            Player player = (Player) sender;
+        if (sender instanceof Entity) {
+            Entity entity = (Entity) sender;
 
-            return ContextResult.ok(() -> player.getWorld());
+            return ContextResult.ok(() -> entity.getWorld());
+        } else if (sender instanceof BlockCommandSender) {
+            BlockCommandSender blockCommandSender = (BlockCommandSender) sender;
+
+            return ContextResult.ok(() -> blockCommandSender.getBlock().getWorld());
         }
 
-        return ContextResult.error(messageRegistry.get(LiteBukkitMessages.WORLD_PLAYER_ONLY, invocation));
+        return ContextResult.error(messageRegistry.get(LiteBukkitMessages.WORLD_NON_CONSOLE_ONLY, invocation));
     }
 
 }

--- a/litecommands-bukkit/src/dev/rollczi/litecommands/bukkit/context/WorldContext.java
+++ b/litecommands-bukkit/src/dev/rollczi/litecommands/bukkit/context/WorldContext.java
@@ -32,7 +32,7 @@ public class WorldContext implements ContextProvider<CommandSender, World> {
             return ContextResult.ok(() -> blockCommandSender.getBlock().getWorld());
         }
 
-        return ContextResult.error(messageRegistry.get(LiteBukkitMessages.WORLD_NON_CONSOLE_ONLY, invocation));
+        return ContextResult.error(messageRegistry.get(LiteBukkitMessages.WORLD_NO_CONSOLE, invocation));
     }
 
 }


### PR DESCRIPTION
World and Location could be retrieved from entities and command blocks but current code does not support to do so.
This issue got fixed in this PR.

PLAYER_ONLY keys may could be deprecated.