### PR TITLE
Updated Minestom Version and removed deprecated ExecutionTypes

### DIFF
--- a/buildSrc/src/main/kotlin/Versions.kt
+++ b/buildSrc/src/main/kotlin/Versions.kt
@@ -22,7 +22,7 @@ object Versions {
     const val JDA = "5.6.1"
 
     // Minestom
-    const val MINESTOM = "7320437640"
+    const val MINESTOM = "2025.07.11-1.21.7"
 
     // Sponge
     const val SPONGE_API = "13.0.0"

--- a/examples/minestom/build.gradle.kts
+++ b/examples/minestom/build.gradle.kts
@@ -15,7 +15,7 @@ repositories {
 }
 
 dependencies {
-    implementation("net.minestom:minestom-snapshots:7320437640")
+    implementation("net.minestom:minestom:${Versions.MINESTOM}")
     implementation("net.kyori:adventure-text-minimessage:4.23.0")
 
     // implementation("dev.rollczi:litecommands-minestom:3.10.2") // <-- uncomment in your project

--- a/litecommands-minestom/build.gradle.kts
+++ b/litecommands-minestom/build.gradle.kts
@@ -10,8 +10,8 @@ dependencies {
     api(project(":litecommands-framework"))
     api(project(":litecommands-adventure"))
     testImplementation(project(":litecommands-annotations"))
-    compileOnly("net.minestom:minestom-snapshots:${Versions.MINESTOM}")
-    testImplementation("net.minestom:minestom-snapshots:${Versions.MINESTOM}")
+    compileOnly("net.minestom:minestom:${Versions.MINESTOM}")
+    testImplementation("net.minestom:minestom:${Versions.MINESTOM}")
 }
 
 litecommandsPublish {

--- a/litecommands-minestom/src/dev/rollczi/litecommands/minestom/MinestomScheduler.java
+++ b/litecommands-minestom/src/dev/rollczi/litecommands/minestom/MinestomScheduler.java
@@ -23,7 +23,7 @@ public class MinestomScheduler implements Scheduler {
             .orElseThrow(() -> new IllegalStateException("Cannot resolve the thread type"));
         CompletableFuture<T> future = new CompletableFuture<>();
         Task.Builder built = scheduler.buildTask(() -> tryRun(supplier, future))
-            .executionType(poll.equals(SchedulerType.MAIN) ? ExecutionType.SYNC : ExecutionType.ASYNC);
+            .executionType(poll.equals(SchedulerType.MAIN) ? ExecutionType.TICK_START : ExecutionType.TICK_END);
 
         if (!delay.isZero()) {
             built.delay(delay);


### PR DESCRIPTION
I replaced the deprecated ExecutionTypes with the correct once used by the latest Minestom version. Furthermore,  I changed the version of Minestom to use the new tag format. 

