### PR TITLE
Use OfflinePlayer#getFirstPlayed instead of OfflinePlayer#hasPlayedBefore to check if a player has ever been on the server

### DIFF
--- a/litecommands-bukkit/src/dev/rollczi/litecommands/bukkit/argument/OfflinePlayerArgument.java
+++ b/litecommands-bukkit/src/dev/rollczi/litecommands/bukkit/argument/OfflinePlayerArgument.java
@@ -68,7 +68,8 @@ public class OfflinePlayerArgument extends ArgumentResolver<CommandSender, Offli
     protected ParseResult<OfflinePlayer> parse(Invocation<CommandSender> invocation, Argument<OfflinePlayer> context, String argument) {
         return ParseResult.async(() -> {
             OfflinePlayer offlinePlayer = server.getOfflinePlayer(argument);
-            if (!offlinePlayer.hasPlayedBefore() && !allowParseUnknownPlayers) {
+            long firstPlayed = offlinePlayer.getFirstPlayed();
+            if (firstPlayed < 1 && !allowParseUnknownPlayers) {
                 return ParseResult.failure(messageRegistry.get(LiteBukkitMessages.OFFLINE_PLAYER_NOT_FOUND, invocation, argument));
             }
             return ParseResult.success(offlinePlayer);


### PR DESCRIPTION
`hasPlayedBefore` function will return `true` only for subsequent player sessions, which means that it will return `false` causing the parser to fail on their first session even if they are online.

Instead, we should use the `getFirstPlayed` function, which will return:
- `0` for players who have never been on the server before
- the correct timestamp even for the player's first session

```
> test # Player never joined before
[14:56:11] [INFO]: hasPlayedBefore: false
[14:56:11] [INFO]: getFirstPlayed: 0
[14:56:21] [INFO]: TestPlayer joined the game # First join
> test
[14:56:21] [INFO]: hasPlayedBefore: false
[14:56:21] [INFO]: getFirstPlayed: 1758372976193
[14:56:41] [INFO]: TestPlayer lost connection: Disconnected
> test
[14:56:44] [INFO]: hasPlayedBefore: true
[14:56:44] [INFO]: getFirstPlayed: 1758372976193
```